### PR TITLE
Task 07

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 CDK_DEFAULT_ACCOUNT=
 CDK_DEFAULT_REGION=
+USERNAME= #github username
+PASSWORD= #basic authorizer password

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: build seed test deploy
+include .env.local
+export
 
 STACK = $(word 2,$(MAKECMDGOALS))
 
@@ -12,4 +13,6 @@ test:
 	go test -v ./...
 
 deploy: build
-	cdk deploy $(if $(STACK),$(STACK),--all)
+	cdk deploy $(if $(STACK),$(STACK),--all) --debug
+
+.PHONY: build seed test deploy

--- a/cmd/aws/main.go
+++ b/cmd/aws/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"aws-shop-backend/packages/authorization"
 	"aws-shop-backend/packages/imports"
 	"aws-shop-backend/packages/products"
 	"os"
@@ -25,11 +26,18 @@ func main() {
 		Env: env(),
 	})
 
+	authorizationStack := authorization.NewStack(app, "AuthorizationStack",
+		&awscdk.StackProps{
+			Env: env(),
+		},
+	)
+
 	importsStack := imports.NewStack(app, "ImportsStack", &awscdk.StackProps{
 		Env: env(),
 	})
 
 	importsStack.AddDependency(productsStack, jsii.String("Products stack must be created first"))
+	importsStack.AddDependency(authorizationStack, jsii.String("Authorization stack must be created first"))
 
 	app.Synth(nil)
 }

--- a/lambdas/basicAuthorizer/main.go
+++ b/lambdas/basicAuthorizer/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+var (
+	username string
+	password string
+)
+
+func init() {
+	username = os.Getenv("USERNAME")
+	password = os.Getenv("PASSWORD")
+	if username == "" || password == "" {
+		log.Fatal("no env variables found")
+	}
+}
+
+func createPolicy(effect string, resource string) events.APIGatewayCustomAuthorizerPolicy {
+	return events.APIGatewayCustomAuthorizerPolicy{
+		Version: "2012-10-17",
+		Statement: []events.IAMPolicyStatement{
+			{
+				Action:   []string{"execute-api:Invoke"},
+				Effect:   effect,
+				Resource: []string{resource},
+			},
+		},
+	}
+}
+
+func handler(
+	event events.APIGatewayCustomAuthorizerRequest,
+) (events.APIGatewayCustomAuthorizerResponse, error) {
+	res := events.APIGatewayCustomAuthorizerResponse{
+		PrincipalID: username,
+	}
+
+	if err := validateToken(event.AuthorizationToken); err != nil {
+		log.Printf("token validation error: %v", err)
+		res.PolicyDocument = createPolicy("Deny", event.MethodArn)
+		return res, nil
+	}
+
+	res.PolicyDocument = createPolicy("Allow", event.MethodArn)
+	return res, nil
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/lambdas/basicAuthorizer/validateToken.go
+++ b/lambdas/basicAuthorizer/validateToken.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+// Validates base64 basic authorization token
+func validateToken(token string) error {
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(token, "Basic "))
+	if err != nil {
+		return err
+	}
+
+	if password != strings.TrimSpace(string(decoded)) {
+		return fmt.Errorf("password is not correct")
+	}
+
+	return nil
+}

--- a/packages/authorization/stack.go
+++ b/packages/authorization/stack.go
@@ -1,0 +1,36 @@
+package authorization
+
+import (
+	"os"
+
+	"github.com/aws/aws-cdk-go/awscdk/v2"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
+	"github.com/aws/constructs-go/constructs/v10"
+	"github.com/aws/jsii-runtime-go"
+)
+
+func NewStack(scope constructs.Construct, id string, props *awscdk.StackProps) awscdk.Stack {
+	stack := awscdk.NewStack(scope, &id, props)
+
+	basicAuthorizerFunction := awslambda.NewFunction(
+		stack, jsii.String("BasicAuthorizerFunction"),
+		&awslambda.FunctionProps{
+			Runtime: awslambda.Runtime_PROVIDED_AL2023(),
+			Code:    awslambda.Code_FromAsset(jsii.String("lambdas/basicAuthorizer"), nil),
+			Handler: jsii.String("bootstrap"),
+			Environment: &map[string]*string{
+				"USERNAME": jsii.String(os.Getenv("USERNAME")),
+				"PASSWORD": jsii.String(os.Getenv("PASSWORD")),
+			},
+		},
+	)
+
+	awscdk.NewCfnOutput(stack, jsii.String("BasicAuthorizerFunctionArn"),
+		&awscdk.CfnOutputProps{
+			Value:      basicAuthorizerFunction.FunctionArn(),
+			ExportName: jsii.String("BasicAuthorizerFunctionArn"),
+		},
+	)
+
+	return stack
+}


### PR DESCRIPTION
## What was done: 
#### Base tasks:
- Authorization stack is added, has basicAuthorizer lambda that checks authorization_token from headers.
- Import Service AWS CDK Stack has authorizer configuration for the importProductsFile lambda. If no token is provided user receives 401 HTTP status. In case of invalid token user receives 403 HTTP status.
- Client application is updated to send "Authorization: Basic authorization_token" header on import endpoint.
#### Additional tasks: 
- Client application displays alerts for the responses in 401 and 403 HTTP statuses. The behavior is implemented with AlertProvider in `/src/index.tsx` file.

## Links: 
- FE pull request: [https://github.com/alehkonan/aws-shop-react/pull/6](https://github.com/alehkonan/aws-shop-react/pull/6)
- Cloudfront: [https://d2rcjsjs5l9fv3.cloudfront.net/admin/products](https://d2rcjsjs5l9fv3.cloudfront.net/admin/products)

## Scenarios:
- When token is removed from localstorage `/import` endpoint responses with 401 status code 
<img width="1511" alt="Screenshot 2025-03-22 at 17 43 12" src="https://github.com/user-attachments/assets/2be40782-725f-410e-8414-af1b3d191821" />

- When token is invalid `/import` endpoint responses with 403 status code
<img width="1511" alt="Screenshot 2025-03-22 at 17 43 35" src="https://github.com/user-attachments/assets/5264b228-c2ea-4e61-b4fc-da86088a6748" />

- When token is correct base64 password `/import` endpoint responses with 200 status code. The correct token is automatically set after page reload .
<img width="1511" alt="Screenshot 2025-03-22 at 19 07 50" src="https://github.com/user-attachments/assets/ba008651-e887-492c-a753-673fc1814b90" />
